### PR TITLE
Puppet linting to improve compatibility

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,19 +10,19 @@
 # Copyright 2103 Ronald Valente
 #
 class avamar (
-    $host       = undef,
-    $domain     = 'clients',
-    $version    = '6.1.100-402',
-    $local_dir  = ''
+  $host       = undef,
+  $domain     = 'clients',
+  $version    = '6.1.100-402',
+  $local_dir  = undef
 ) {
-  class {'avamar::params':
+  class {'::avamar::params':
     host      => $host,
     domain    => $domain,
     version   => $version,
     local_dir => $local_dir,
-  } ->
-  class {'avamar::install':
-  } -> 
-  class {'avamar::register':
+  }
+  -> class {'::avamar::install':
+  }
+  -> class {'::avamar::register':
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,14 +10,14 @@
 class avamar::install inherits avamar::params {
 
   if($avamar::params::local_dir == ''){
-    include wget
+    include ::wget
     $base_url  = "https://${avamar::params::host}"
     $pkg_url   = "${base_url}${avamar::params::pkg_loc}"
     # Hostname must be a string
-    validate_string($host)
+    validate_string($avamar::params::host)
 
-    wget::fetch { "avamar_pkg":
-      source             => "$pkg_url",
+    wget::fetch { 'avamar_pkg':
+      source             => $pkg_url,
       destination        => "${avamar::params::pkg_dir}/${avamar::params::pkg}",
       timeout            => 0,
       verbose            => false,
@@ -26,15 +26,16 @@ class avamar::install inherits avamar::params {
     }
 
     package { $avamar::params::pkg_name:
+      ensure   => installed,
       provider => $avamar::params::provider,
-      ensure   => installed,
       source   => "${avamar::params::pkg_dir}/${avamar::params::pkg}",
-      require  => Wget::Fetch["avamar_pkg"],
+      require  => Wget::Fetch['avamar_pkg'],
     }
-  }else{
-      package { $avamar::params::pkg_name:
-      ensure   => installed,
-      source   => "$avamar::params::local_dir",
+  }
+  else {
+    package { $avamar::params::pkg_name:
+      ensure          => installed,
+      source          => $avamar::params::local_dir,
       install_options => ['/qn'],
     }
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -9,7 +9,7 @@
 #
 class avamar::install inherits avamar::params {
 
-  if($avamar::params::local_dir == ''){
+  if($avamar::params::local_dir == undef){
     include ::wget
     $base_url  = "https://${avamar::params::host}"
     $pkg_url   = "${base_url}${avamar::params::pkg_loc}"

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,7 @@ class avamar::params (
   $version,
   $local_dir,
 ) {
-  
+
   $pkg_dir    = '/usr/local/src'
   $avagent    = '/usr/local/avamar/etc/avagent.d'
   $base       = 'AvamarClient'
@@ -27,31 +27,36 @@ class avamar::params (
       case $::lsbmajdistrelease {
         /(4|5)/: {
           case $::architecture {
-            'x86_64': {
-              $pkg_name = "${base}-${version}.x86_64"
-              $pkg      = "${base}-linux-rhel4-x86_64-${version}.${type}"
-              $pkg_loc  = "/DPNInstalls/downloads/RHEL5-X86_64/${pkg}"
-            }
             'i386': {
               $pkg_name = "${base}-${version}.i386"
               $pkg      = "${base}-linux-rhel4-x86-${version}.${type}"
               $pkg_loc  = "/DPNInstalls/downloads/RHEL5/${pkg}"
             }
+            default: {
+              $pkg_name = "${base}-${version}.x86_64"
+              $pkg      = "${base}-linux-rhel4-x86_64-${version}.${type}"
+              $pkg_loc  = "/DPNInstalls/downloads/RHEL5-X86_64/${pkg}"
+            }
           }
         }
         '6': {
           case $::architecture {
-            'x86_64': {
-              $pkg_name = "${base}-${version}.x86_64"
-              $pkg      = "${base}-linux-sles11-x86_64-${version}.${type}"
-              $pkg_loc  = "/DPNInstalls/downloads/RHEL6-X86_64/${pkg}"
-            }
             'i386': {
               $pkg_name = "${base}-${version}.i386"
               $pkg      = "${base}-linux-sles11-x86-${version}.${type}"
               $pkg_loc  = "/DPNInstalls/downloads/RHEL6/${pkg}"
             }
+            default: {
+              $pkg_name = "${base}-${version}.x86_64"
+              $pkg      = "${base}-linux-sles11-x86_64-${version}.${type}"
+              $pkg_loc  = "/DPNInstalls/downloads/RHEL6-X86_64/${pkg}"
+            }
           }
+        }
+        default: {
+          $pkg_name = "${base}-${version}.x86_64"
+          $pkg      = "${base}-linux-sles11-x86_64-${version}.${type}"
+          $pkg_loc  = "/DPNInstalls/downloads/RHEL${::lsbmajdistrelease}-X86_64/${pkg}"
         }
       }
     }
@@ -61,45 +66,45 @@ class avamar::params (
       case $::lsbmajdistrelease {
         '10':{
           case $::architecture {
-            'x86_64': {
-              $pkg_name = "${base}-${version}.x86_64"
-              $pkg      = "${base}-linux-rhel4-x86_64-${version}.${type}"
-              $pkg_loc  = "/DPNInstalls/downloads/SLES10-X86_64/${pkg}"
-            }
             'i386': {
               $pkg_name = "${base}-${version}.i386"
               $pkg      = "${base}-linux-rhel4-x86-${version}.${type}"
               $pkg_loc  = "/DPNInstalls/downloads/SLES10/${pkg}"
             }
+            default: {
+              $pkg_name = "${base}-${version}.x86_64"
+              $pkg      = "${base}-linux-rhel4-x86_64-${version}.${type}"
+              $pkg_loc  = "/DPNInstalls/downloads/SLES10-X86_64/${pkg}"
+            }
           }
         }
-        '11':{          
+        default:{
           case $::architecture {
-            'x86_64': {
-              $pkg_name = "${base}-${version}.x86_64"
-              $pkg      = "${base}-linux-sles11-x86_64-${version}.${type}"
-              $pkg_loc  = "/DPNInstalls/downloads/SLES11-X86_64/${pkg}"
-            }
             'i386': {
               $pkg_name = "${base}-${version}.i386"
               $pkg      = "${base}-linux-sles11-x86-${version}.${type}"
               $pkg_loc  = "/DPNInstalls/downloads/SLES11/${pkg}"
             }
+            default: {
+              $pkg_name = "${base}-${version}.x86_64"
+              $pkg      = "${base}-linux-sles11-x86_64-${version}.${type}"
+              $pkg_loc  = "/DPNInstalls/downloads/SLES11-X86_64/${pkg}"
+            }
           }
-        }         
+        }
       }
     }
     'Solaris': {
       $provider = 'sun'
       $type     = 'pkg'
       case $::architecture {
-        'x86_64': {
-          $pkg      = "${base}-solaris10-x86_64-${version}.${type}"
-          $pkg_loc  = "/DPNInstalls/downloads/SOL5.10_X86_64/${pkg}"
-        }
         'i386': {
           $pkg      = "${base}-solaris10-x86-${version}.${type}"
           $pkg_loc  = "/DPNInstalls/downloads/SOL5.10_X86/${pkg}"
+        }
+        default: {
+          $pkg      = "${base}-solaris10-x86_64-${version}.${type}"
+          $pkg_loc  = "/DPNInstalls/downloads/SOL5.10_X86_64/${pkg}"
         }
       }
     }
@@ -108,20 +113,20 @@ class avamar::params (
       $pkg_name = 'avamarclient-debian'
       $type     = 'deb'
       case $::architecture {
-        'amd64': {
-          $pkg     = "${base}-debian4.0-x86_64-${version}.${type}"
-          $pkg_loc = "/DPNInstalls/downloads/DEBIAN_LINUX_64/${pkg}"
-        }
         'i386': {
           $pkg     = "${base}-debian4.0-x86-${version}.${type}"
           $pkg_loc = "/DPNInstalls/downloads/DEBIAN_LINUX/${pkg}"
+        }
+        default: {
+          $pkg     = "${base}-debian4.0-x86_64-${version}.${type}"
+          $pkg_loc = "/DPNInstalls/downloads/DEBIAN_LINUX_64/${pkg}"
         }
       }
     }
     'Windows': {
       $provider = 'windows'
       $type     = 'msi'
-      $pkg_name = "EMC Avamar for Windows"
+      $pkg_name = 'EMC Avamar for Windows'
       case $::architecture {
         'amd64': {
           $pkg      = "${base}-windows-x86_64-${version}.${type}"
@@ -137,6 +142,9 @@ class avamar::params (
           $pkg     = "${base}-windows-x86-${version}.${type}"
           $pkg_loc = "/DPNInstalls/downloads/WIN32/${pkg}"
           $pkg_path = "C:\\Program Files (x86)\\avs\\bin\\"
+        }
+        default: {
+          fail("Module ${module_name} is not supported on ${::osfamily} ${::architecture}")
         }
       }
     }

--- a/manifests/register.pp
+++ b/manifests/register.pp
@@ -11,16 +11,16 @@
 class avamar::register inherits avamar::params {
 
   case $::osfamily {
-    Windows: {
+    'Windows': {
       exec { 'register':
         command     => "cd \"${avamar::params::pkg_path}\"; .\\avregister.bat \"${avamar::params::host}\" \"${avamar::params::domain}\";",
         refreshonly => true,
         subscribe   => Class['avamar::install'],
-        provider    => "powershell",
-      } ->
-      service { 'avbackup':
-        enable     => true,
+        provider    => 'powershell',
+      }
+      -> service { 'avbackup':
         ensure     => running,
+        enable     => true,
         hasrestart => true,
         hasstatus  => true,
         require    => Class['avamar::install'],
@@ -28,17 +28,17 @@ class avamar::register inherits avamar::params {
     }
     default: {
       exec { 'register':
-        command     => "$avamar::params::avagent register $avamar::params::host $avamar::params::domain",
-        path        => [ "/bin/", "/sbin/" , "/usr/bin/", "/usr/sbin/", "/usr/local/bin", "/usr/local/sbin" ],
-        onlyif      => "test `$avamar::params::avagent status | grep -c $avamar::params::host` -ne 1",
+        command     => "${avamar::params::avagent} register ${avamar::params::host} ${avamar::params::domain}",
+        path        => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/', '/usr/local/bin', '/usr/local/sbin' ],
+        onlyif      => "test `${avamar::params::avagent} status | grep -c ${avamar::params::host}` -ne 1",
         refreshonly => true,
         subscribe   => Class['avamar::install'],
         before      => Service['avagent'],
       }
 
       service { 'avagent':
-        enable     => true,
         ensure     => running,
+        enable     => true,
         hasrestart => true,
         hasstatus  => true,
         require    => Class['avamar::install'],


### PR DESCRIPTION
Most of the fixes are just a matter of following the [Puppet Language Style Guide](https://docs.puppet.com/puppet/4.10/style_guide.html).

An added benefit to providing default CASE statements is that this module can now handle RHEL >=7.

Another important fix is the IF statement at the top of install.pp. Checking if `local_dir == ''` is a problem if you're running Puppet 3.8 with future parser enabled or Puppet >=4. If `local_dir` is actually set to `undef`, the value is evaluated as `false`. Testing with empty quotes converts to `true`, since the empty quotes is a non-boolean value. So, `local_dir = undef` does **NOT** == empty quotes.

See [Check Your Comparisons](https://docs.puppet.com/puppet/3.8/experiments_future.html#check-your-comparisons) for an explanation.